### PR TITLE
fix: upgrade Phoenixd to resolve reconnect leak

### DIFF
--- a/scripts/test-phoenixd-runtime.sh
+++ b/scripts/test-phoenixd-runtime.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+expected="v0.8.0"
+actual=$(git -C submodules/phoenixd describe --tags --exact-match 2>/dev/null || true)
+if [[ "$actual" != "$expected" ]]; then
+  echo "phoenixd submodule must be pinned to $expected, got ${actual:-unversioned}" >&2
+  exit 1
+fi
+
+if grep -q 'PHOENIXD_BRANCH=v0.3.3' submodules/phoenixd/.docker/Dockerfile; then
+  echo "legacy Phoenixd 0.3.3 JVM image still configured" >&2
+  exit 1
+fi
+
+if ! grep -q 'phoenixdReleaseExecutable' submodules/phoenixd/.docker/Dockerfile; then
+  echo "expected modern native Phoenixd image build" >&2
+  exit 1
+fi
+
+echo "phoenixd runtime pin: $expected (native build)"


### PR DESCRIPTION
## Summary

- upgrade the Phoenixd submodule from v0.3.3-era code to upstream v0.8.0
- move from the legacy JVM runtime to upstream's current native runtime image
- add a regression script that rejects the vulnerable v0.3.3 pin

## Root cause

The hosted Phoenixd process eventually opened 524,288 descriptors and entered a Lightning TCP reconnect loop, logging `java.io.IOException: No file descriptors available`, using ~100% CPU and ~1.8 GiB RAM.

Upstream Phoenixd v0.5.0 explicitly lists **“Fixed a memory leak in the TCP reconnection logic”**. This repository was still pinned to v0.3.3 from August 2024. v0.8.0 is the current upstream release and includes that fix plus subsequent DB migration fixes and Lightning/Ktor updates.

## Safety

Before production cutover, the candidate image will be tested against a backup copy of the mounted Phoenixd data. The original `2_phoenixd` directory will not be modified during compatibility testing, and rollback retains the current image and data backup.

## Verification

- `scripts/test-phoenixd-runtime.sh`
- upstream release and Dockerfile pin verified at v0.8.0
